### PR TITLE
Spring boot core basic

### DIFF
--- a/src/main/java/com/fastcampus/springboottoyboard/OrderApp.java
+++ b/src/main/java/com/fastcampus/springboottoyboard/OrderApp.java
@@ -11,6 +11,7 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 public class OrderApp {
     public static void main(String[] args) {
 
+        // ApplicationContext를 스프링 컨테이너라고 한다.
         ApplicationContext applicationContext = new AnnotationConfigApplicationContext(AppConfig.class);
         MemberService memberService = applicationContext.getBean("memberService", MemberService.class);
         OrderService orderService = applicationContext.getBean("orderService", OrderService.class);

--- a/src/main/resources/appConfig.xml
+++ b/src/main/resources/appConfig.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+    <bean id="memberService" class="com.fastcampus.springboottoyboard.member.MemberServiceImpl">
+        <constructor-arg name="memberRepository" ref="memberRepository" />
+    </bean>
+    <bean id="memberRepository" class="com.fastcampus.springboottoyboard.member.MemoryMemberRepository" />
+    <bean id="orderService" class="com.fastcampus.springboottoyboard.order.OrderServiceImpl">
+        <constructor-arg name="memberRepository" ref="memberRepository" />
+        <constructor-arg name="discountPolicy" ref="discountPolicy" />
+    </bean>
+    <bean id="discountPolicy" class="com.fastcampus.springboottoyboard.discount.RateDiscountPolicy" />
+</beans>

--- a/src/test/java/com/fastcampus/springboottoyboard/beandefinition/BeanDefinitionTest.java
+++ b/src/test/java/com/fastcampus/springboottoyboard/beandefinition/BeanDefinitionTest.java
@@ -1,0 +1,26 @@
+package com.fastcampus.springboottoyboard.beandefinition;
+
+import com.fastcampus.springboottoyboard.AppConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+public class BeanDefinitionTest {
+
+    AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext(AppConfig.class);
+
+    @Test
+    @DisplayName("빈 실행 메타정보 확인")
+    void findApplicationBean() {
+        String[] beanDefinitionNames = ac.getBeanDefinitionNames();
+        for (String beanDefinitionName : beanDefinitionNames) {
+            BeanDefinition beanDefinition = ac.getBeanDefinition(beanDefinitionName);
+
+            if (beanDefinition.getRole() == BeanDefinition.ROLE_APPLICATION) {
+                System.out.println("beanDefinitionName = " + beanDefinitionName
+                        + " beanDefinition = " + beanDefinition);
+            }
+        }
+    }
+}

--- a/src/test/java/com/fastcampus/springboottoyboard/beandefinition/BeanDefinitionTest.java
+++ b/src/test/java/com/fastcampus/springboottoyboard/beandefinition/BeanDefinitionTest.java
@@ -13,6 +13,8 @@ public class BeanDefinitionTest {
     @Test
     @DisplayName("빈 실행 메타정보 확인")
     void findApplicationBean() {
+
+        // Bean Definition을 실제로 쓸일이 별로 없다.
         String[] beanDefinitionNames = ac.getBeanDefinitionNames();
         for (String beanDefinitionName : beanDefinitionNames) {
             BeanDefinition beanDefinition = ac.getBeanDefinition(beanDefinitionName);

--- a/src/test/java/com/fastcampus/springboottoyboard/beanfind/ApplicationContextBasicFindTest.java
+++ b/src/test/java/com/fastcampus/springboottoyboard/beanfind/ApplicationContextBasicFindTest.java
@@ -1,0 +1,47 @@
+package com.fastcampus.springboottoyboard.beanfind;
+
+import com.fastcampus.springboottoyboard.AppConfig;
+import com.fastcampus.springboottoyboard.member.MemberService;
+import com.fastcampus.springboottoyboard.member.MemberServiceImpl;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.boot.web.reactive.context.AnnotationConfigReactiveWebApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ApplicationContextBasicFindTest {
+    AnnotationConfigApplicationContext ac = new AnnotationConfigReactiveWebApplicationContext(AppConfig.class);
+
+
+    @Test
+    @DisplayName("빈 이름으로 조회")
+    void findBeanByName() {
+        MemberService memberService = ac.getBean("memberService", MemberService.class);
+        Assertions.assertThat(memberService).isInstanceOf(MemberServiceImpl.class);
+    }
+
+    @Test
+    @DisplayName("이름 없이 타입으로만 조회")
+    void findBeanByType() {
+        MemberService memberService = ac.getBean(MemberService.class);
+        Assertions.assertThat(memberService).isInstanceOf(MemberServiceImpl.class);
+    }
+
+    // 구현에 의존한 방식 : 좋지 않은 방식
+    @Test
+    @DisplayName("구체 타입으로 조회")
+    void findBeanByType2() {
+        MemberService memberService = ac.getBean("memberService", MemberServiceImpl.class);
+        Assertions.assertThat(memberService).isInstanceOf(MemberServiceImpl.class);
+    }
+    
+    @Test
+    @DisplayName("빈 이름으로 조회X")
+    void findBeanByNameX() {
+        assertThrows(NoSuchBeanDefinitionException.class,
+                () -> ac.getBean("xxxxx", MemberService.class));
+    }
+}

--- a/src/test/java/com/fastcampus/springboottoyboard/beanfind/ApplicationContextExtendsFindTest.java
+++ b/src/test/java/com/fastcampus/springboottoyboard/beanfind/ApplicationContextExtendsFindTest.java
@@ -1,0 +1,75 @@
+package com.fastcampus.springboottoyboard.beanfind;
+
+import com.fastcampus.springboottoyboard.discount.DiscountPolicy;
+import com.fastcampus.springboottoyboard.discount.FixDiscountPolicy;
+import com.fastcampus.springboottoyboard.discount.RateDiscountPolicy;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Map;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ApplicationContextExtendsFindTest {
+    AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext(TestConfig.class);
+
+    @Test
+    @DisplayName("부모 타입으로 조회시, 자식이 둘 이상 있으면, 중복 오류가 발생한다.")
+    void findBeanByParentTypeDuplicate() {
+        assertThrows(NoUniqueBeanDefinitionException.class,
+                () -> ac.getBean(DiscountPolicy.class));
+    }
+
+    @Test
+    @DisplayName("부모 타입으로 조회시, 자식이 둘 이상 있으면, 빈 이름을 지정하면 된다.")
+    void findBeanByParentTypeBeanName() {
+        DiscountPolicy rateDiscountPolicy = ac.getBean("rateDiscountPolicy", DiscountPolicy.class);
+        assertThat(rateDiscountPolicy).isInstanceOf(RateDiscountPolicy.class);
+    }
+
+    @Test
+    @DisplayName("특정 하위 타입으로 조회")
+    void findBeanBySubType() {
+        RateDiscountPolicy bean = ac.getBean(RateDiscountPolicy.class);
+        assertThat(bean).isInstanceOf(RateDiscountPolicy.class);
+    }
+
+    @Test
+    @DisplayName("부모 타입으로 모두 조회하기")
+    void findAllBeanByParentType() {
+        Map<String, DiscountPolicy> beansOfType = ac.getBeansOfType(DiscountPolicy.class);
+        assertThat(beansOfType.size()).isEqualTo(2);
+        for (String s : beansOfType.keySet()) {
+            System.out.println("key = " + s + " value = " + beansOfType.get(s));
+        }
+    }
+
+    @Test
+    @DisplayName("부모 타입으로 모두 조회하기 - Object")
+    void findAllBeanByObjectType() {
+        Map<String, Object> beansOfType = ac.getBeansOfType(Object.class);
+        assertThat(beansOfType.size()).isEqualTo(2);
+        for (String s : beansOfType.keySet()) {
+            System.out.println("key = " + s + " value = " + beansOfType.get(s));
+        }
+    }
+
+    @Configuration
+    static class TestConfig {
+
+        @Bean
+        public DiscountPolicy rateDiscountPolicy() {
+            return new RateDiscountPolicy();
+        }
+
+        @Bean
+        public DiscountPolicy fixDiscountPolicy() {
+            return new FixDiscountPolicy();
+        }
+    }
+}

--- a/src/test/java/com/fastcampus/springboottoyboard/beanfind/ApplicationContextInfoTest.java
+++ b/src/test/java/com/fastcampus/springboottoyboard/beanfind/ApplicationContextInfoTest.java
@@ -1,0 +1,39 @@
+package com.fastcampus.springboottoyboard.beanfind;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.boot.web.reactive.context.AnnotationConfigReactiveWebApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import com.fastcampus.springboottoyboard.AppConfig;
+
+public class ApplicationContextInfoTest {
+
+    AnnotationConfigApplicationContext ac = new AnnotationConfigReactiveWebApplicationContext(AppConfig.class);
+
+    @Test
+    @DisplayName("모든 빈 출력하기")
+    void findAllBean() {
+        String[] beanDefinitionNames = ac.getBeanDefinitionNames();
+        for (String beanDefinitionName : beanDefinitionNames) {
+            Object bean = ac.getBean(beanDefinitionName);
+            System.out.println("name = " + beanDefinitionName + " object = " + bean);
+        }
+    }
+
+    @Test
+    @DisplayName("애플리케이션 빈 출력하기")
+    void findApplicationBean() {
+        String[] beanDefinitionNames = ac.getBeanDefinitionNames();
+        for (String beanDefinitionName : beanDefinitionNames) {
+            BeanDefinition beanDefinition = ac.getBeanDefinition(beanDefinitionName);
+
+            // Role ROLE_APPLICATION: 직접 등록한 애플리케이션 빈
+            // Role ROLE_INFRASTRUCTURE: 스프링이 내부에서 사용하는 빈
+            if (beanDefinition.getRole() == BeanDefinition.ROLE_APPLICATION) {
+                Object bean = ac.getBean(beanDefinitionName);
+                System.out.println("name = " + beanDefinitionName + " object = " + bean);
+            }
+        }
+    }
+}

--- a/src/test/java/com/fastcampus/springboottoyboard/beanfind/ApplicationContextSameBeanFindTest.java
+++ b/src/test/java/com/fastcampus/springboottoyboard/beanfind/ApplicationContextSameBeanFindTest.java
@@ -1,0 +1,59 @@
+package com.fastcampus.springboottoyboard.beanfind;
+
+import com.fastcampus.springboottoyboard.member.MemberRepository;
+import com.fastcampus.springboottoyboard.member.MemoryMemberRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ApplicationContextSameBeanFindTest {
+
+    AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext(SameBeanConfig.class);
+
+    @Test
+    @DisplayName("타입으로 조회시 같은 타입이 둘 이상 있으면, 중복 오류가 발생한다.")
+    void findBeanByTypeDuplicate() {
+        // MemberRepository bean = ac.getBean(MemberRepository.class);
+        assertThrows(NoUniqueBeanDefinitionException.class, () -> ac.getBean(MemberRepository.class));
+    }
+
+    @Test
+    @DisplayName("타입으로 조회시 같은 타입이 둘 이상 있으면, 빈 이름을 지정할 것.")
+    void findBeanByName() {
+        MemberRepository bean = ac.getBean("memberRepository1", MemberRepository.class);
+        Assertions.assertThat(bean).isInstanceOf(MemberRepository.class);
+    }
+
+    @Test
+    @DisplayName("특정 타입을 모두 조회하기")
+    void findAllBeanByType() {
+        Map<String, MemberRepository> beansOfType = ac.getBeansOfType(MemberRepository.class);
+        for (String s : beansOfType.keySet()) {
+            System.out.println("key = " + s + " value = " + beansOfType.get(s));
+        }
+        Assertions.assertThat(beansOfType.size()).isEqualTo(2);
+    }
+
+
+    @Configuration
+    static class SameBeanConfig {
+
+        @Bean
+        public MemberRepository memberRepository1() {
+            return new MemoryMemberRepository();
+        }
+
+        @Bean
+        public MemberRepository memberRepository2() {
+            return new MemoryMemberRepository();
+        }
+    }
+}

--- a/src/test/java/com/fastcampus/springboottoyboard/singleton/SingletonService.java
+++ b/src/test/java/com/fastcampus/springboottoyboard/singleton/SingletonService.java
@@ -1,0 +1,21 @@
+package com.fastcampus.springboottoyboard.singleton;
+
+public class SingletonService {
+
+    // 이 변수는 클래스의 모든 인스턴스에서 공유되며, 값을 변경할 수 없다.
+    // static = 클래스 변수
+    // final 변경하지 못하는 참조값
+    private static final SingletonService instance = new SingletonService();
+
+    public static SingletonService getInstance() {
+        return instance;
+    }
+
+    // 생성자를 private으로 막아서 외부에서 new로 객체 인스턴스가 생성되는 것을 막는다.
+    private SingletonService() {
+    }
+
+    public void logic() {
+        System.out.println("싱글톤 객체 호출");
+    }
+}

--- a/src/test/java/com/fastcampus/springboottoyboard/singleton/SingletonTest.java
+++ b/src/test/java/com/fastcampus/springboottoyboard/singleton/SingletonTest.java
@@ -1,0 +1,54 @@
+package com.fastcampus.springboottoyboard.singleton;
+
+import com.fastcampus.springboottoyboard.AppConfig;
+import com.fastcampus.springboottoyboard.member.MemberService;
+import org.apache.catalina.core.ApplicationContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SingletonTest {
+
+    @Test
+    @DisplayName("스프링 없는 순수한 DI 컨테이너")
+    void pureContainer() {
+
+        AppConfig appConfig = new AppConfig();
+
+        MemberService memberService1 = appConfig.memberService();
+
+        MemberService memberService2 = appConfig.memberService();
+
+        System.out.println("memberService1 = " + memberService1);
+        System.out.println("memberService2 = " + memberService2);
+
+        assertThat(memberService1).isNotSameAs(memberService2);
+    }
+
+    @Test
+    @DisplayName("싱글톤 패턴을 적용한 객체 사용")
+    void singletonServiceTest() {
+        SingletonService instance1 = SingletonService.getInstance();
+        SingletonService instance2 = SingletonService.getInstance();
+
+        assertThat(instance1).isSameAs(instance2);
+    }
+
+    @Test
+    @DisplayName("스프링 컨테이너와 싱글톤")
+    void springContainer() {
+
+        AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext(AppConfig.class);
+        // ApplicationContext ac = new AnnotationConfigApplicationContext(AppConfig.class);
+
+        MemberService memberService1 = ac.getBean("memberService", MemberService.class);
+        MemberService memberService2 = ac.getBean("memberService", MemberService.class);
+
+        System.out.println("memberService1 = " + memberService1);
+        System.out.println("memberService2 = " + memberService2);
+
+        assertThat(memberService1).isSameAs(memberService2);
+    }
+}

--- a/src/test/java/com/fastcampus/springboottoyboard/singleton/StatefulService.java
+++ b/src/test/java/com/fastcampus/springboottoyboard/singleton/StatefulService.java
@@ -1,0 +1,16 @@
+package com.fastcampus.springboottoyboard.singleton;
+
+public class StatefulService {
+
+    private int price; // 상태를 유지하는 필드
+
+    public void order(String name, int price) {
+        System.out.println("name = " + name + " price = " + price);
+        this.price = price;
+    }
+
+    public int getPrice() {
+        return price;
+    }
+
+}

--- a/src/test/java/com/fastcampus/springboottoyboard/singleton/StatefulServiceTest.java
+++ b/src/test/java/com/fastcampus/springboottoyboard/singleton/StatefulServiceTest.java
@@ -1,0 +1,38 @@
+package com.fastcampus.springboottoyboard.singleton;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+
+
+class StatefulServiceTest {
+
+    @Test
+    void statefulServiceSingleton() {
+        AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext(TestConfig.class);
+
+        StatefulService statefulService1 = ac.getBean(StatefulService.class);
+        StatefulService statefulService2 = ac.getBean(StatefulService.class);
+
+        // ThreadA : A 사용자 10000원 주문
+        // statefulService1.order("userA", 10000);
+
+        // ThreadB : B 사용자 20000원 주문
+        // statefulService2.order("userB", 20000);
+
+        // 실무에서 이런 장애는 잡기도 어렵다 ...
+        int price1 = statefulService1.getPrice();
+        System.out.println("price = " + price1);
+
+        Assertions.assertThat(statefulService1.getPrice()).isEqualTo(20000);
+    }
+
+    static class TestConfig {
+        @Bean
+        public StatefulService statefulService() {
+            return new StatefulService();
+        }
+    }
+
+}

--- a/src/test/java/com/fastcampus/springboottoyboard/xml/XmlAppContext.java
+++ b/src/test/java/com/fastcampus/springboottoyboard/xml/XmlAppContext.java
@@ -1,0 +1,17 @@
+package com.fastcampus.springboottoyboard.xml;
+
+import com.fastcampus.springboottoyboard.member.MemberService;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.GenericXmlApplicationContext;
+
+public class XmlAppContext {
+
+    @Test
+    void xmlAppContext() {
+        ApplicationContext ac = new GenericXmlApplicationContext("appConfig.xml");
+        MemberService memberService = ac.getBean("memberService", MemberService.class);
+        Assertions.assertThat(memberService).isInstanceOf(MemberService.class);
+    }
+}


### PR DESCRIPTION
싱글톤 패턴에 대하여 배움

스프링 컨테이너는 객체를 싱글톤으로 관리하여 서버 부하를 줄일 수 있다.
  - (물론 요즘 컴퓨터에서는 싱글톤 객체를 사용하지 않고도 충분히 부하를 감당할 수 있다.)
  - 어떤 객체를 싱글톤으로 만드는 것은 생성자 함수를 private으로 지정하고 자기자신을 클래스 변수로 바로 선언하여 인스턴스로 지니고 있다는 것을 의미함
  - getInstance 등의 static메서드를 사용하여 인스턴스를 조회할 수 있다.

따라서 여러 코드에서 동일한 객체를 호출한다면 유일한 인스턴스를 사용하여 작업을 하고 있음을 의미함
단, 싱글톤 패턴을 사용할 경우 절대적으로 내부 변수를 바꿀 수 있도록 설계해선 안됨! (서비스가 망하는 경우)